### PR TITLE
Icon validation fix

### DIFF
--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -132,10 +132,9 @@ func (a *WebAPI) postIdent(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if len(icon) != DogeIconSize && len(icon) != 0 {
-		    http.Error(w, fmt.Sprintf("invalid icon: expecting %v bytes (got %v)", DogeIconSize, len(icon)), http.StatusBadRequest)
-		    return
+				http.Error(w, fmt.Sprintf("invalid icon: expecting %v bytes (got %v)", DogeIconSize, len(icon)), http.StatusBadRequest)
+				return
 		}
-
 
 		pro := spec.Profile{
 			Name:    to.Name,

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -131,10 +131,11 @@ func (a *WebAPI) postIdent(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("invalid icon: %v", err.Error()), http.StatusBadRequest)
 			return
 		}
-		if len(icon) != dnet.DogeIconSize && len(icon) != 0 {
-			http.Error(w, fmt.Sprintf("invalid icon: expecting %v bytes (got %v)", DogeIconSize, len(icon)), http.StatusBadRequest)
-			return
+		if len(icon) != DogeIconSize && len(icon) != 0 {
+		    http.Error(w, fmt.Sprintf("invalid icon: expecting %v bytes (got %v)", DogeIconSize, len(icon)), http.StatusBadRequest)
+		    return
 		}
+
 
 		pro := spec.Profile{
 			Name:    to.Name,

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -132,8 +132,8 @@ func (a *WebAPI) postIdent(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if len(icon) != DogeIconSize && len(icon) != 0 {
-				http.Error(w, fmt.Sprintf("invalid icon: expecting %v bytes (got %v)", DogeIconSize, len(icon)), http.StatusBadRequest)
-				return
+			http.Error(w, fmt.Sprintf("invalid icon: expecting %v bytes (got %v)", DogeIconSize, len(icon)), http.StatusBadRequest)
+			return
 		}
 
 		pro := spec.Profile{


### PR DESCRIPTION
Currently the api returns a 400 `invalid icon: expecting 1585 bytes (got 1585)`, rejecting icons submitted from the frontend.

This tweak accepts icons submitted from the frontend.